### PR TITLE
Remove unsafe calls from Rust version

### DIFF
--- a/src/rust/fastinvsqrt.rs
+++ b/src/rust/fastinvsqrt.rs
@@ -1,9 +1,9 @@
 use std::io::BufRead;
 
 fn fast_inv_sqrt(x: f32) -> f32 {
-    let i: u32 = unsafe { std::mem::transmute(x) };
+    let i = x.to_bits();
     let j = 0x5f3759df - (i >> 1);
-    let y: f32 = unsafe { std::mem::transmute(j) };
+    let y = f32::from_bits(j);
     y * (1.5 - 0.5 * x * y * y)
 }
 


### PR DESCRIPTION
[Rust 1.20 (August 2017)](https://blog.rust-lang.org/2017/08/31/Rust-1.20.html) added [f32::from_bits](https://doc.rust-lang.org/std/primitive.f32.html#method.from_bits) and [f32::to_bits](https://doc.rust-lang.org/std/primitive.f32.html#method.to_bits) which do exactly what we want, safely.

At the moment, it's literally just a safe proxy to transmute, though I guess that could change on platforms where that doesn't work properly.